### PR TITLE
Add CLI options to print only unowned files and exit w/error status if any files are unowned

### DIFF
--- a/bin/code_owners
+++ b/bin/code_owners
@@ -10,11 +10,21 @@ OptionParser.new do |opts|
   opts.on('-u', '--unowned', TrueClass, 'Display unowned files only') do |u|
     options[:unowned] = u
   end
+  opts.on('-e', '--error-unowned', TrueClass, 'Exit with error status if any files are unowned') do |e|
+    options[:error_unowned] = e
+  end
 end.parse!
 
+unowned_error = false
 CodeOwners.ownerships.each do |ownership_status|
   owner_info = ownership_status[:owner].dup
-  next if options[:unowned] && owner_info != CodeOwners::NO_OWNER
+  if owner_info != CodeOwners::NO_OWNER
+    next if options[:unowned]
+  else
+    unowned_error ||= options[:error_unowned]
+  end
   owner_info += " per line #{ownership_status[:line]}, #{ownership_status[:pattern]}" if owner_info != "UNOWNED"
   puts "#{ownership_status[:file].ljust(100,' ')} #{owner_info}"
 end
+
+exit(unowned_error && 1 || 0)

--- a/bin/code_owners
+++ b/bin/code_owners
@@ -2,9 +2,19 @@
 
 $LOAD_PATH << File.join(File.dirname(__FILE__), '..', 'lib')
 require 'code_owners'
+require 'optparse'
+
+options = {}
+OptionParser.new do |opts|
+  opts.banner = "usage: code_owners [options]"
+  opts.on('-u', '--unowned', TrueClass, 'Display unowned files only') do |u|
+    options[:unowned] = u
+  end
+end.parse!
 
 CodeOwners.ownerships.each do |ownership_status|
   owner_info = ownership_status[:owner].dup
+  next if options[:unowned] && owner_info != CodeOwners::NO_OWNER
   owner_info += " per line #{ownership_status[:line]}, #{ownership_status[:pattern]}" if owner_info != "UNOWNED"
   puts "#{ownership_status[:file].ljust(100,' ')} #{owner_info}"
 end

--- a/lib/code_owners.rb
+++ b/lib/code_owners.rb
@@ -2,7 +2,9 @@ require "code_owners/version"
 require "tempfile"
 
 module CodeOwners
+  NO_OWNER = 'UNOWNED'
   class << self
+
     # github's CODEOWNERS rules (https://help.github.com/articles/about-codeowners/) are allegedly based on the gitignore format.
     # but you can't tell ls-files to ignore tracked files via an arbitrary pattern file
     # so we need to jump through some hacky git-fu hoops
@@ -21,7 +23,7 @@ module CodeOwners
       patterns = pattern_owners
       git_owner_info(patterns.map { |p| p[0] }).map do |line, pattern, file|
         if line.empty?
-          { file: file, owner: "UNOWNED", line: nil, pattern: nil }
+          { file: file, owner: NO_OWNER, line: nil, pattern: nil }
         else
           {
             file: file,


### PR DESCRIPTION
In addition to being a nice-to-have, this (and the option to exit with error status if any files are unowned) will enable us to more easily write our CI ownership tests without piping to grep. 

This makes it way easier to finagle it in such a way that should `code_owners` hits an error, the CI script exits with error status, ensuring no false negatives in the CI test.