### PR TITLE
Output better error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@ Install
 
     gem install code_owners
 
+Requirements
+============
+
+* Ruby
+* Git
+
 Usage
 =====
 

--- a/bin/code_owners
+++ b/bin/code_owners
@@ -1,5 +1,15 @@
 #!/usr/bin/env ruby
 
+unless system('git --version > /dev/null')
+  STDERR.puts 'Git does not appear to be installed.'
+  exit 2
+end
+
+unless system('git rev-parse --is-inside-work-tree > /dev/null')
+  STDERR.puts 'The current working directory must be a Git repo.'
+  exit 3
+end
+
 $LOAD_PATH << File.join(File.dirname(__FILE__), '..', 'lib')
 require 'code_owners'
 require 'optparse'


### PR DESCRIPTION
When Git is missing, it used to be:

```
/usr/local/bundle/gems/code_owners-1.0.7/lib/code_owners.rb:98:in ``': No such file or directory - git (Errno::ENOENT)
```

When the cwd is not a repo, it used to be:

```
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
[ERROR] CODEOWNERS file does not exist.
```