### PR TITLE
Fix unicode filename ownership

### DIFF
--- a/lib/code_owners.rb
+++ b/lib/code_owners.rb
@@ -77,7 +77,7 @@ module CodeOwners
       Tempfile.open('codeowner_patterns') do |file|
         file.write(patterns.join("\n"))
         file.rewind
-        `cd #{current_repo_path} && git ls-files | xargs -- git -c \"core.excludesfile=#{file.path}\" check-ignore --no-index -v -n`
+        `cd #{current_repo_path} && git -c \"core.quotepath=off\" ls-files | xargs -- git -c \"core.quotepath=off\" -c \"core.excludesfile=#{file.path}\" check-ignore --no-index -v -n`
       end
     end
 


### PR DESCRIPTION
Currently filenames like e.g. `some/path/☃.txt` will always fail ownership tests due to inconsistencies in filename treatment. By temporarily adding `core.quotepath off` to our git configuration we can keep git from octal-escaping unicode filenames, removing the inconsistency