### PR TITLE
fix raw_git_owner_info when path includes spaces

### DIFF
--- a/lib/code_owners.rb
+++ b/lib/code_owners.rb
@@ -77,7 +77,7 @@ module CodeOwners
       Tempfile.open('codeowner_patterns') do |file|
         file.write(patterns.join("\n"))
         file.rewind
-        `cd #{current_repo_path} && git -c \"core.quotepath=off\" ls-files | xargs -- git -c \"core.quotepath=off\" -c \"core.excludesfile=#{file.path}\" check-ignore --no-index -v -n`
+        `cd #{current_repo_path} && git -c \"core.quotepath=off\" ls-files -z | xargs -0 -- git -c \"core.quotepath=off\" -c \"core.excludesfile=#{file.path}\" check-ignore --no-index -v -n`
       end
     end
 

--- a/spec/code_owners_spec.rb
+++ b/spec/code_owners_spec.rb
@@ -86,6 +86,13 @@ CODEOWNERS
       expect(raw_ownership.size).to be >= 1
       expect(raw_ownership).to match(/^(?:.*:\d*:.*\t.*\n)+$/)
     end
+
+    context "when path includes a space" do
+      it "returns the path in single line" do
+        raw_ownership = CodeOwners.raw_git_owner_info(["/spec/files/*"])
+        expect(raw_ownership).to match(/.+:\d+:.+\tspec\/files\/file name\.txt\n/)
+      end
+    end
   end
 
   describe "code_owners" do

--- a/spec/files/file name.txt
+++ b/spec/files/file name.txt
@@ -1,0 +1,1 @@
+This file's name includes a space.


### PR DESCRIPTION
When path includes spaces, `raw_git_owner_info` returns broken strings like below.

```
/tmp/codeowner_patterns20220222-1949232-m8w7nj:1:/spec/files/*  spec/files/file
::      name.txt
```

It should be this.

```
/tmp/codeowner_patterns20220222-1949232-m8w7nj:1:/spec/files/*  spec/files/file name.txt
```

FYI:
https://stackoverflow.com/questions/41085382/how-do-i-run-a-command-on-all-files-from-git-ls-files