### PR TITLE
Implements a "pure ruby" git matching behavior

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,7 @@
 
 # empty line followed by a comment?!  madness
 lib/*                   @jcheatham
+**/bar/** @jcheatham
 spec/*                  @jcheatham
 Rakefile                @jcheatham
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,12 +2,14 @@ PATH
   remote: .
   specs:
     code_owners (1.0.9)
+      pathspec
       rake
 
 GEM
   remote: http://rubygems.org/
   specs:
     diff-lcs (1.3)
+    pathspec (0.2.1)
     rake (13.0.6)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)

--- a/bin/code_owners
+++ b/bin/code_owners
@@ -15,7 +15,7 @@ require 'code_owners'
 require 'code_owners/version'
 require 'optparse'
 
-options = {}
+options = {ignores: []}
 OptionParser.new do |opts|
   opts.banner = "usage: code_owners [options]"
   opts.on('-u', '--unowned', TrueClass, 'Display unowned files only') do |u|
@@ -23,6 +23,9 @@ OptionParser.new do |opts|
   end
   opts.on('-e', '--error-unowned', TrueClass, 'Exit with error status if any files are unowned') do |e|
     options[:error_unowned] = e
+  end
+  opts.on('-i', '--ignore FILE', String, 'A file of gitignore patterns to filter out of results, may be specified multiple times') do |i|
+    options[:ignores] << i
   end
   opts.on('-n', '--no-git', TrueClass, '[experimental] Use a git-free, pure ruby based implementation') do |n|
      options[:no_git] = n

--- a/bin/code_owners
+++ b/bin/code_owners
@@ -27,6 +27,9 @@ OptionParser.new do |opts|
   opts.on('-i', '--ignore FILE', String, 'A file of gitignore patterns to filter out of results, may be specified multiple times') do |i|
     options[:ignores] << i
   end
+  opts.on('-l', '--log', TrueClass, 'Log stuff') do |l|
+    options[:log] = l
+  end
   opts.on('-n', '--no-git', TrueClass, '[experimental] Use a git-free, pure ruby based implementation') do |n|
      options[:no_git] = n
    end

--- a/code_owners.gemspec
+++ b/code_owners.gemspec
@@ -19,4 +19,5 @@ Gem::Specification.new name, CodeOwners::VERSION do |s|
 
   s.add_development_dependency "rspec"
   s.add_runtime_dependency "rake"
+  s.add_runtime_dependency "pathspec"
 end

--- a/lib/code_owners.rb
+++ b/lib/code_owners.rb
@@ -17,6 +17,7 @@ module CodeOwners
 
     # this maps the collection of ownership patterns and owners to actual files
     def ownerships(opts = {})
+      log("Calculating ownerships for #{opts.inspect}", opts)
       patterns = pattern_owners(codeowners_data(opts), opts)
       if opts[:no_git]
         files = files_to_own(opts)
@@ -111,14 +112,14 @@ module CodeOwners
 
         elsif stripped_line.start_with?("!")
           # unsupported per github spec
-          log "Parse error line #{(i+1).to_s}: \"#{line}\""
+          log("Parse error line #{(i+1).to_s}: \"#{line}\"", opts)
           patterns << ['', '']
 
         elsif stripped_line.match(CODEOWNER_PATTERN)
           patterns << [$1, $2]
 
         else
-          log "Parse error line #{(i+1).to_s}: \"#{line}\""
+          log("Parse error line #{(i+1).to_s}: \"#{line}\"", opts)
           patterns << ['', '']
 
         end
@@ -126,8 +127,8 @@ module CodeOwners
       patterns
     end
 
-    def log(message)
-      puts message
+    def log(message, opts = {})
+      puts message if opts[:log]
     end
 
     private
@@ -175,7 +176,7 @@ module CodeOwners
 
       # filter out ignores if we have them
       opts[:ignores]&.each do |ignore|
-        ignores = PathSpec.from_filename(ignore)
+        ignores = PathSpec.new(File.readlines(ignore, chomp: true).map{|i| i.end_with?("/*") ? "#{i}*" : i })
         all_files.reject! { |f| ignores.specs.any?{|p| p.match(f) } }
       end
 

--- a/spec/code_owners_spec.rb
+++ b/spec/code_owners_spec.rb
@@ -124,13 +124,27 @@ CODEOWNERS
     end
   end
 
-  describe ".search_codeowners_file" do
+  describe ".codeowners_data" do
+    context "when passed predefined data" do
+      it "returns the data" do
+        result = CodeOwners.send(:codeowners_data, codeowner_data: "foo")
+        expect(result).to eq("foo")
+      end
+    end
+
+    context "when passed a file path" do
+      it "loads the file" do
+        result = CodeOwners.send(:codeowners_data, codeowner_path: ".github/CODEOWNERS")
+        expect(result).to start_with("# This is a CODEOWNERS file.")
+      end
+    end
+
     context "using git" do
       it "works when in a sub-directory" do
         Dir.chdir("lib") do
-          result = CodeOwners.search_codeowners_file
+          result = CodeOwners.send(:codeowners_data)
           # assuming cloned to a directory named after the repo
-          expect(result).to end_with("code_owners/.github/CODEOWNERS")
+          expect(result).to start_with("# This is a CODEOWNERS file.")
         end
       end
 
@@ -138,7 +152,7 @@ CODEOWNERS
         Dir.chdir("/") do
           # this should also print out an error to stderror along the lines of
           # fatal: not a git repository (or any of the parent directories): .git
-          expect { CodeOwners.search_codeowners_file }.to raise_error(RuntimeError)
+          expect { CodeOwners.send(:codeowners_data) }.to raise_error(RuntimeError)
         end
       end
     end
@@ -146,15 +160,15 @@ CODEOWNERS
     context "not using git" do
       it "works when in a sub-directory" do
         Dir.chdir("lib") do
-          result = CodeOwners.search_codeowners_file(no_git: true)
+          result = CodeOwners.send(:codeowners_data, no_git: true)
           # assuming cloned to a directory named after the repo
-          expect(result).to end_with("code_owners/.github/CODEOWNERS")
+          expect(result).to start_with("# This is a CODEOWNERS file.")
         end
       end
 
       it "fails when not in a repo" do
         Dir.chdir("/") do
-          expect { CodeOwners.search_codeowners_file(no_git: true) }.to raise_error(RuntimeError)
+          expect { CodeOwners.send(:codeowners_data, no_git: true) }.to raise_error(RuntimeError)
         end
       end
     end

--- a/spec/code_owners_spec.rb
+++ b/spec/code_owners_spec.rb
@@ -174,6 +174,21 @@ CODEOWNERS
     end
   end
 
+  describe ".files_to_own" do
+    it "returns all files" do
+      result = CodeOwners.send(:files_to_own)
+      expect(result).to include('/Gemfile')
+      expect(result).to include('/lib/code_owners.rb')
+      expect(result).to include('/spec/files/foo/fake_gem.gem')
+    end
+
+    it "removes ignored files" do
+      result = CodeOwners.send(:files_to_own, ignores: [".gitignore"])
+      expect(result).to include('/spec/files/foo/bar/baz/baz.txt')
+      expect(result).not_to include('/spec/files/foo/fake_gem.gem')
+    end
+  end
+
   describe "code_owners" do
     VERSION_REGEX = /Version: \d+\.\d+\.\d+(-[a-z0-9]+)?/i
 

--- a/spec/code_owners_spec.rb
+++ b/spec/code_owners_spec.rb
@@ -130,9 +130,9 @@ CODEOWNERS
     end
 
     it "prints validation errors and skips lines that aren't the expected format" do
-      expect(CodeOwners).to receive(:log).with("Parse error line 8: \"invalid/code owners/line\"")
-      expect(CodeOwners).to receive(:log).with("Parse error line 9: \"     @AnotherInvalidLine\"")
-      expect(CodeOwners).to receive(:log).with("Parse error line 11: \"!this/is/unsupported.txt   @foo\"")
+      expect(CodeOwners).to receive(:log).with("Parse error line 8: \"invalid/code owners/line\"", {})
+      expect(CodeOwners).to receive(:log).with("Parse error line 9: \"     @AnotherInvalidLine\"", {})
+      expect(CodeOwners).to receive(:log).with("Parse error line 11: \"!this/is/unsupported.txt   @foo\"", {})
       pattern_owners = CodeOwners.pattern_owners(@data)
       expect(pattern_owners).not_to include(["", "@AnotherInvalidLine"])
       expect(pattern_owners).to include(["", ""])

--- a/spec/code_owners_spec.rb
+++ b/spec/code_owners_spec.rb
@@ -185,4 +185,16 @@ CODEOWNERS
       expect(`bin#{File::SEPARATOR}code_owners --version`).to match VERSION_REGEX
     end
   end
+
+  # yoinked from rspec match_array
+  def array_diff(array_1, array_2)
+    difference = array_1.dup
+    array_2.each do |element|
+      if index = difference.index(element)
+        difference.delete_at(index)
+      end
+    end
+    difference
+  end
+
 end

--- a/spec/files/.dot folder/.silly example.txt
+++ b/spec/files/.dot folder/.silly example.txt
@@ -1,0 +1,1 @@
+just git ignore things

--- a/spec/files/.dot folder/afoodle.txt
+++ b/spec/files/.dot folder/afoodle.txt
@@ -1,0 +1,1 @@
+This is afoodle.txt

--- a/spec/files/.dot folder/serious_example.txt
+++ b/spec/files/.dot folder/serious_example.txt
@@ -1,0 +1,1 @@
+This is serious business

--- a/spec/files/.gitignore
+++ b/spec/files/.gitignore
@@ -1,0 +1,1 @@
+blah blah blah

--- a/spec/files/foo/bar/bar
+++ b/spec/files/foo/bar/bar
@@ -1,0 +1,1 @@
+This is bar

--- a/spec/files/foo/bar/bar.txt
+++ b/spec/files/foo/bar/bar.txt
@@ -1,0 +1,1 @@
+This is bar.txt

--- a/spec/files/foo/bar/baz/baz.txt
+++ b/spec/files/foo/bar/baz/baz.txt
@@ -1,0 +1,1 @@
+This is spec/files/foo/bar/baz/baz.txt

--- a/spec/files/foo/bar/baz/baz2.txt
+++ b/spec/files/foo/bar/baz/baz2.txt
@@ -1,0 +1,1 @@
+This is baz2.txt

--- a/spec/files/foo/bar/some bar.txt
+++ b/spec/files/foo/bar/some bar.txt
@@ -1,0 +1,1 @@
+This is some bar.txt

--- a/spec/files/foo/confoozing.txt
+++ b/spec/files/foo/confoozing.txt
@@ -1,0 +1,1 @@
+This is confoozing.txt

--- a/spec/files/foo/fake_gem.gem
+++ b/spec/files/foo/fake_gem.gem
@@ -1,0 +1,1 @@
+This is a fake gem to trigger .gitignore

--- a/spec/files/foo/foo
+++ b/spec/files/foo/foo
@@ -1,0 +1,1 @@
+this is a foo file

--- a/spec/files/foo/foo.txt
+++ b/spec/files/foo/foo.txt
@@ -1,0 +1,1 @@
+this is foo.txt

--- a/spec/files/foo/some foo.text
+++ b/spec/files/foo/some foo.text
@@ -1,0 +1,1 @@
+true facts

--- a/spec/generate_permutations.rb
+++ b/spec/generate_permutations.rb
@@ -1,0 +1,55 @@
+#!/usr/bin/env ruby
+
+require 'code_owners'
+require 'tmpdir'
+require 'json'
+
+output = { permutations: {} }
+
+Dir.chdir("spec/files") do
+  all_files = Dir.glob(File.join(".","**","**"), File::FNM_DOTMATCH)
+  all_files.reject! { |f| File.directory?(f) }
+  output[:all_files] = all_files
+
+  permutables = ["", "*", ".", "/", "*/", "/*", "**", "**/", "/**", "**/**", "*/**", "**/*"]
+  ignore_cases = permutables.map do |p1|
+    ["foo", "bar", "foo/bar"].map do |p2|
+      permutables.map do |p3|
+        "#{p1}#{p2}#{p3}"
+      end
+    end
+  end.flatten
+
+  # can add more one-off cases we want to evaluate here
+  ignore_cases << ".dot*"
+
+  ignore_cases.sort!
+  puts "Evaluating #{ignore_cases.size} permutations"
+
+  Tempfile.open('codeowner_patterns') do |file|
+    ignore_cases.each do |perm|
+      puts "evaluating #{perm}"
+      file.rewind
+      file.write(perm)
+      file.flush
+      file.truncate(file.pos)
+      ignore_matches = []
+      ignore_results = `find . -type f -print0 | xargs -0 -- git -c "core.quotepath=off" -c "core.excludesfile=#{file.path}" check-ignore --no-index -v -n`
+      ignore_results.scan(/^([^:]+):(\d+):([^\t]*)\t(.*)/).each do |m_source, m_line, m_pattern, m_file|
+        if m_source != file.path || m_line != "1" || m_pattern != perm
+          puts "ERROR?!"
+          puts "#{m_source.inspect} == #{file.path.inspect}"
+          puts "#{m_line.inspect} == 1"
+          puts "#{m_pattern.inspect} == #{perm.inspect}"
+          puts ignore_results
+        end
+        ignore_matches << m_file
+      end
+      output[:permutations][perm] = ignore_matches.sort
+    end
+  end
+end
+
+File.open("spec/permutations.json", "w+") do |perm_file|
+  perm_file.write(JSON.pretty_generate(output))
+end

--- a/spec/generate_permutations.rb
+++ b/spec/generate_permutations.rb
@@ -3,11 +3,30 @@
 require 'code_owners'
 require 'tmpdir'
 require 'json'
+require 'pathname'
+require 'byebug'
 
 output = { permutations: {} }
 
+def reset_file_to(file, content)
+  file.rewind
+  file.write(content)
+  file.flush
+  file.truncate(file.pos)
+end
+
+# UGGGGGH
+# so, turns out, the part in git-scm where it says
+# > A trailing "/**" matches everything inside. For example, "abc/**" matches all files inside directory "abc", relative to the location of the .gitignore file, with infinite depth.
+# that "relative" bit gets REAL obnoxious when it comes to trying to evaluate using an adhoc core.excludesFile directive
+# speaking of, it seems like if you have one defined in the tree of a project git will STILL use that
+# see the special exception case mentioned below for the *.gem pattern conflicting with the project's .gitignore
+# there was no way to replace/unset it I could find that doesn't affect something more permanent >:/
+
+ignore_file = File.open("spec/files/.gitignore", "w+")
+
 Dir.chdir("spec/files") do
-  all_files = Dir.glob(File.join(".","**","**"), File::FNM_DOTMATCH)
+  all_files = Dir.glob(File.join("**","**"), File::FNM_DOTMATCH)
   all_files.reject! { |f| File.directory?(f) }
   output[:all_files] = all_files
 
@@ -26,28 +45,28 @@ Dir.chdir("spec/files") do
   ignore_cases.sort!
   puts "Evaluating #{ignore_cases.size} permutations"
 
-  Tempfile.open('codeowner_patterns') do |file|
-    ignore_cases.each do |perm|
-      puts "evaluating #{perm}"
-      file.rewind
-      file.write(perm)
-      file.flush
-      file.truncate(file.pos)
-      ignore_matches = []
-      ignore_results = `find . -type f -print0 | xargs -0 -- git -c "core.quotepath=off" -c "core.excludesfile=#{file.path}" check-ignore --no-index -v -n`
-      ignore_results.scan(/^([^:]+):(\d+):([^\t]*)\t(.*)/).each do |m_source, m_line, m_pattern, m_file|
-        if m_source != file.path || m_line != "1" || m_pattern != perm
-          puts "ERROR?!"
-          puts "#{m_source.inspect} == #{file.path.inspect}"
-          puts "#{m_line.inspect} == 1"
-          puts "#{m_pattern.inspect} == #{perm.inspect}"
-          puts ignore_results
-        end
-        ignore_matches << m_file
+  rootpath = Pathname.new(".")
+
+  ignore_cases.each do |perm|
+    puts "evaluating #{perm}"
+    reset_file_to(ignore_file, perm)
+    ignore_matches = []
+    ignore_results = `find . -type f | sed "s|^\./||" | tr '\n' '\\0' | xargs -0 -- git -c "core.quotepath=off" check-ignore --no-index -v -n`
+    ignore_results.scan(/^([^:]+):(\d+):([^\t]*)\t(.*)/).each do |m_source, m_line, m_pattern, m_file|
+      if m_source != ignore_file.path || m_line != "1" || m_pattern != perm
+        next if m_source == ".gitignore" && m_line == "1" && m_pattern == "*.gem"
+        puts "ERROR?!"
+        puts "expecting #{ignore_file.path.inspect}, got #{m_source.inspect}"
+        puts "expecting 1, got #{m_line.inspect}"
+        puts "expecting #{perm.inspect}, got #{m_pattern.inspect}"
+        puts ignore_results
       end
-      output[:permutations][perm] = ignore_matches.sort
+      ignore_matches << Pathname.new(m_file).relative_path_from(rootpath).to_s
     end
+    output[:permutations][perm] = ignore_matches.sort
   end
+
+  reset_file_to(ignore_file, "blah blah blah")
 end
 
 File.open("spec/permutations.json", "w+") do |perm_file|

--- a/spec/permutations.json
+++ b/spec/permutations.json
@@ -1,0 +1,1937 @@
+{
+  "permutations": {
+    "**/**bar": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/**bar*": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/**bar**": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/**bar**/": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/**bar**/*": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/**bar**/**": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/**bar*/": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/**bar*/**": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/**bar.": [
+
+    ],
+    "**/**bar/": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/**bar/*": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/**bar/**": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/**foo": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt",
+      "./foo/confoozing.txt",
+      "./foo/foo",
+      "./foo/foo.txt",
+      "./foo/some foo.text"
+    ],
+    "**/**foo*": [
+      "./.dot folder/afoodle.txt",
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt",
+      "./foo/confoozing.txt",
+      "./foo/foo",
+      "./foo/foo.txt",
+      "./foo/some foo.text"
+    ],
+    "**/**foo**": [
+      "./.dot folder/afoodle.txt",
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt",
+      "./foo/confoozing.txt",
+      "./foo/foo",
+      "./foo/foo.txt",
+      "./foo/some foo.text"
+    ],
+    "**/**foo**/": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt",
+      "./foo/confoozing.txt",
+      "./foo/foo",
+      "./foo/foo.txt",
+      "./foo/some foo.text"
+    ],
+    "**/**foo**/*": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt",
+      "./foo/confoozing.txt",
+      "./foo/foo",
+      "./foo/foo.txt",
+      "./foo/some foo.text"
+    ],
+    "**/**foo**/**": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt",
+      "./foo/confoozing.txt",
+      "./foo/foo",
+      "./foo/foo.txt",
+      "./foo/some foo.text"
+    ],
+    "**/**foo*/": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt",
+      "./foo/confoozing.txt",
+      "./foo/foo",
+      "./foo/foo.txt",
+      "./foo/some foo.text"
+    ],
+    "**/**foo*/**": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt",
+      "./foo/confoozing.txt",
+      "./foo/foo",
+      "./foo/foo.txt",
+      "./foo/some foo.text"
+    ],
+    "**/**foo.": [
+
+    ],
+    "**/**foo/": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt",
+      "./foo/confoozing.txt",
+      "./foo/foo",
+      "./foo/foo.txt",
+      "./foo/some foo.text"
+    ],
+    "**/**foo/*": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt",
+      "./foo/confoozing.txt",
+      "./foo/foo",
+      "./foo/foo.txt",
+      "./foo/some foo.text"
+    ],
+    "**/**foo/**": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt",
+      "./foo/confoozing.txt",
+      "./foo/foo",
+      "./foo/foo.txt",
+      "./foo/some foo.text"
+    ],
+    "**/**foo/bar": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/**foo/bar*": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/**foo/bar**": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/**foo/bar**/": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/**foo/bar**/*": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/**foo/bar**/**": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/**foo/bar*/": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/**foo/bar*/**": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/**foo/bar.": [
+
+    ],
+    "**/**foo/bar/": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/**foo/bar/*": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/**foo/bar/**": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/*bar": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/*bar*": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/*bar**": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/*bar**/": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/*bar**/*": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/*bar**/**": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/*bar*/": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/*bar*/**": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/*bar.": [
+
+    ],
+    "**/*bar/": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/*bar/*": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/*bar/**": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/*foo": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt",
+      "./foo/confoozing.txt",
+      "./foo/foo",
+      "./foo/foo.txt",
+      "./foo/some foo.text"
+    ],
+    "**/*foo*": [
+      "./.dot folder/afoodle.txt",
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt",
+      "./foo/confoozing.txt",
+      "./foo/foo",
+      "./foo/foo.txt",
+      "./foo/some foo.text"
+    ],
+    "**/*foo**": [
+      "./.dot folder/afoodle.txt",
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt",
+      "./foo/confoozing.txt",
+      "./foo/foo",
+      "./foo/foo.txt",
+      "./foo/some foo.text"
+    ],
+    "**/*foo**/": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt",
+      "./foo/confoozing.txt",
+      "./foo/foo",
+      "./foo/foo.txt",
+      "./foo/some foo.text"
+    ],
+    "**/*foo**/*": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt",
+      "./foo/confoozing.txt",
+      "./foo/foo",
+      "./foo/foo.txt",
+      "./foo/some foo.text"
+    ],
+    "**/*foo**/**": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt",
+      "./foo/confoozing.txt",
+      "./foo/foo",
+      "./foo/foo.txt",
+      "./foo/some foo.text"
+    ],
+    "**/*foo*/": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt",
+      "./foo/confoozing.txt",
+      "./foo/foo",
+      "./foo/foo.txt",
+      "./foo/some foo.text"
+    ],
+    "**/*foo*/**": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt",
+      "./foo/confoozing.txt",
+      "./foo/foo",
+      "./foo/foo.txt",
+      "./foo/some foo.text"
+    ],
+    "**/*foo.": [
+
+    ],
+    "**/*foo/": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt",
+      "./foo/confoozing.txt",
+      "./foo/foo",
+      "./foo/foo.txt",
+      "./foo/some foo.text"
+    ],
+    "**/*foo/*": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt",
+      "./foo/confoozing.txt",
+      "./foo/foo",
+      "./foo/foo.txt",
+      "./foo/some foo.text"
+    ],
+    "**/*foo/**": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt",
+      "./foo/confoozing.txt",
+      "./foo/foo",
+      "./foo/foo.txt",
+      "./foo/some foo.text"
+    ],
+    "**/*foo/bar": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/*foo/bar*": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/*foo/bar**": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/*foo/bar**/": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/*foo/bar**/*": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/*foo/bar**/**": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/*foo/bar*/": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/*foo/bar*/**": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/*foo/bar.": [
+
+    ],
+    "**/*foo/bar/": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/*foo/bar/*": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/*foo/bar/**": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/bar": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/bar*": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/bar**": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/bar**/": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/bar**/*": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/bar**/**": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/bar*/": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/bar*/**": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/bar.": [
+
+    ],
+    "**/bar/": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/bar/*": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/bar/**": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/foo": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt",
+      "./foo/confoozing.txt",
+      "./foo/foo",
+      "./foo/foo.txt",
+      "./foo/some foo.text"
+    ],
+    "**/foo*": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt",
+      "./foo/confoozing.txt",
+      "./foo/foo",
+      "./foo/foo.txt",
+      "./foo/some foo.text"
+    ],
+    "**/foo**": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt",
+      "./foo/confoozing.txt",
+      "./foo/foo",
+      "./foo/foo.txt",
+      "./foo/some foo.text"
+    ],
+    "**/foo**/": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt",
+      "./foo/confoozing.txt",
+      "./foo/foo",
+      "./foo/foo.txt",
+      "./foo/some foo.text"
+    ],
+    "**/foo**/*": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt",
+      "./foo/confoozing.txt",
+      "./foo/foo",
+      "./foo/foo.txt",
+      "./foo/some foo.text"
+    ],
+    "**/foo**/**": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt",
+      "./foo/confoozing.txt",
+      "./foo/foo",
+      "./foo/foo.txt",
+      "./foo/some foo.text"
+    ],
+    "**/foo*/": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt",
+      "./foo/confoozing.txt",
+      "./foo/foo",
+      "./foo/foo.txt",
+      "./foo/some foo.text"
+    ],
+    "**/foo*/**": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt",
+      "./foo/confoozing.txt",
+      "./foo/foo",
+      "./foo/foo.txt",
+      "./foo/some foo.text"
+    ],
+    "**/foo.": [
+
+    ],
+    "**/foo/": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt",
+      "./foo/confoozing.txt",
+      "./foo/foo",
+      "./foo/foo.txt",
+      "./foo/some foo.text"
+    ],
+    "**/foo/*": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt",
+      "./foo/confoozing.txt",
+      "./foo/foo",
+      "./foo/foo.txt",
+      "./foo/some foo.text"
+    ],
+    "**/foo/**": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt",
+      "./foo/confoozing.txt",
+      "./foo/foo",
+      "./foo/foo.txt",
+      "./foo/some foo.text"
+    ],
+    "**/foo/bar": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/foo/bar*": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/foo/bar**": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/foo/bar**/": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/foo/bar**/*": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/foo/bar**/**": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/foo/bar*/": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/foo/bar*/**": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/foo/bar.": [
+
+    ],
+    "**/foo/bar/": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/foo/bar/*": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**/foo/bar/**": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**bar": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**bar*": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**bar**": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**bar**/": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**bar**/*": [
+
+    ],
+    "**bar**/**": [
+
+    ],
+    "**bar*/": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**bar*/**": [
+
+    ],
+    "**bar.": [
+
+    ],
+    "**bar/": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "**bar/*": [
+
+    ],
+    "**bar/**": [
+
+    ],
+    "**foo": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt",
+      "./foo/confoozing.txt",
+      "./foo/foo",
+      "./foo/foo.txt",
+      "./foo/some foo.text"
+    ],
+    "**foo*": [
+      "./.dot folder/afoodle.txt",
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt",
+      "./foo/confoozing.txt",
+      "./foo/foo",
+      "./foo/foo.txt",
+      "./foo/some foo.text"
+    ],
+    "**foo**": [
+      "./.dot folder/afoodle.txt",
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt",
+      "./foo/confoozing.txt",
+      "./foo/foo",
+      "./foo/foo.txt",
+      "./foo/some foo.text"
+    ],
+    "**foo**/": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt",
+      "./foo/confoozing.txt",
+      "./foo/foo",
+      "./foo/foo.txt",
+      "./foo/some foo.text"
+    ],
+    "**foo**/*": [
+
+    ],
+    "**foo**/**": [
+
+    ],
+    "**foo*/": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt",
+      "./foo/confoozing.txt",
+      "./foo/foo",
+      "./foo/foo.txt",
+      "./foo/some foo.text"
+    ],
+    "**foo*/**": [
+
+    ],
+    "**foo.": [
+
+    ],
+    "**foo/": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt",
+      "./foo/confoozing.txt",
+      "./foo/foo",
+      "./foo/foo.txt",
+      "./foo/some foo.text"
+    ],
+    "**foo/*": [
+
+    ],
+    "**foo/**": [
+
+    ],
+    "**foo/bar": [
+
+    ],
+    "**foo/bar*": [
+
+    ],
+    "**foo/bar**": [
+
+    ],
+    "**foo/bar**/": [
+
+    ],
+    "**foo/bar**/*": [
+
+    ],
+    "**foo/bar**/**": [
+
+    ],
+    "**foo/bar*/": [
+
+    ],
+    "**foo/bar*/**": [
+
+    ],
+    "**foo/bar.": [
+
+    ],
+    "**foo/bar/": [
+
+    ],
+    "**foo/bar/*": [
+
+    ],
+    "**foo/bar/**": [
+
+    ],
+    "*/**bar": [
+
+    ],
+    "*/**bar*": [
+
+    ],
+    "*/**bar**": [
+
+    ],
+    "*/**bar**/": [
+
+    ],
+    "*/**bar**/*": [
+
+    ],
+    "*/**bar**/**": [
+
+    ],
+    "*/**bar*/": [
+
+    ],
+    "*/**bar*/**": [
+
+    ],
+    "*/**bar.": [
+
+    ],
+    "*/**bar/": [
+
+    ],
+    "*/**bar/*": [
+
+    ],
+    "*/**bar/**": [
+
+    ],
+    "*/**foo": [
+
+    ],
+    "*/**foo*": [
+
+    ],
+    "*/**foo**": [
+
+    ],
+    "*/**foo**/": [
+
+    ],
+    "*/**foo**/*": [
+
+    ],
+    "*/**foo**/**": [
+
+    ],
+    "*/**foo*/": [
+
+    ],
+    "*/**foo*/**": [
+
+    ],
+    "*/**foo.": [
+
+    ],
+    "*/**foo/": [
+
+    ],
+    "*/**foo/*": [
+
+    ],
+    "*/**foo/**": [
+
+    ],
+    "*/**foo/bar": [
+
+    ],
+    "*/**foo/bar*": [
+
+    ],
+    "*/**foo/bar**": [
+
+    ],
+    "*/**foo/bar**/": [
+
+    ],
+    "*/**foo/bar**/*": [
+
+    ],
+    "*/**foo/bar**/**": [
+
+    ],
+    "*/**foo/bar*/": [
+
+    ],
+    "*/**foo/bar*/**": [
+
+    ],
+    "*/**foo/bar.": [
+
+    ],
+    "*/**foo/bar/": [
+
+    ],
+    "*/**foo/bar/*": [
+
+    ],
+    "*/**foo/bar/**": [
+
+    ],
+    "*/bar": [
+
+    ],
+    "*/bar*": [
+
+    ],
+    "*/bar**": [
+
+    ],
+    "*/bar**/": [
+
+    ],
+    "*/bar**/*": [
+
+    ],
+    "*/bar**/**": [
+
+    ],
+    "*/bar*/": [
+
+    ],
+    "*/bar*/**": [
+
+    ],
+    "*/bar.": [
+
+    ],
+    "*/bar/": [
+
+    ],
+    "*/bar/*": [
+
+    ],
+    "*/bar/**": [
+
+    ],
+    "*/foo": [
+
+    ],
+    "*/foo*": [
+
+    ],
+    "*/foo**": [
+
+    ],
+    "*/foo**/": [
+
+    ],
+    "*/foo**/*": [
+
+    ],
+    "*/foo**/**": [
+
+    ],
+    "*/foo*/": [
+
+    ],
+    "*/foo*/**": [
+
+    ],
+    "*/foo.": [
+
+    ],
+    "*/foo/": [
+
+    ],
+    "*/foo/*": [
+
+    ],
+    "*/foo/**": [
+
+    ],
+    "*/foo/bar": [
+
+    ],
+    "*/foo/bar*": [
+
+    ],
+    "*/foo/bar**": [
+
+    ],
+    "*/foo/bar**/": [
+
+    ],
+    "*/foo/bar**/*": [
+
+    ],
+    "*/foo/bar**/**": [
+
+    ],
+    "*/foo/bar*/": [
+
+    ],
+    "*/foo/bar*/**": [
+
+    ],
+    "*/foo/bar.": [
+
+    ],
+    "*/foo/bar/": [
+
+    ],
+    "*/foo/bar/*": [
+
+    ],
+    "*/foo/bar/**": [
+
+    ],
+    "*bar": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "*bar*": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "*bar**": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "*bar**/": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "*bar**/*": [
+
+    ],
+    "*bar**/**": [
+
+    ],
+    "*bar*/": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "*bar*/**": [
+
+    ],
+    "*bar.": [
+
+    ],
+    "*bar/": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "*bar/*": [
+
+    ],
+    "*bar/**": [
+
+    ],
+    "*foo": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt",
+      "./foo/confoozing.txt",
+      "./foo/foo",
+      "./foo/foo.txt",
+      "./foo/some foo.text"
+    ],
+    "*foo*": [
+      "./.dot folder/afoodle.txt",
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt",
+      "./foo/confoozing.txt",
+      "./foo/foo",
+      "./foo/foo.txt",
+      "./foo/some foo.text"
+    ],
+    "*foo**": [
+      "./.dot folder/afoodle.txt",
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt",
+      "./foo/confoozing.txt",
+      "./foo/foo",
+      "./foo/foo.txt",
+      "./foo/some foo.text"
+    ],
+    "*foo**/": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt",
+      "./foo/confoozing.txt",
+      "./foo/foo",
+      "./foo/foo.txt",
+      "./foo/some foo.text"
+    ],
+    "*foo**/*": [
+
+    ],
+    "*foo**/**": [
+
+    ],
+    "*foo*/": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt",
+      "./foo/confoozing.txt",
+      "./foo/foo",
+      "./foo/foo.txt",
+      "./foo/some foo.text"
+    ],
+    "*foo*/**": [
+
+    ],
+    "*foo.": [
+
+    ],
+    "*foo/": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt",
+      "./foo/confoozing.txt",
+      "./foo/foo",
+      "./foo/foo.txt",
+      "./foo/some foo.text"
+    ],
+    "*foo/*": [
+
+    ],
+    "*foo/**": [
+
+    ],
+    "*foo/bar": [
+
+    ],
+    "*foo/bar*": [
+
+    ],
+    "*foo/bar**": [
+
+    ],
+    "*foo/bar**/": [
+
+    ],
+    "*foo/bar**/*": [
+
+    ],
+    "*foo/bar**/**": [
+
+    ],
+    "*foo/bar*/": [
+
+    ],
+    "*foo/bar*/**": [
+
+    ],
+    "*foo/bar.": [
+
+    ],
+    "*foo/bar/": [
+
+    ],
+    "*foo/bar/*": [
+
+    ],
+    "*foo/bar/**": [
+
+    ],
+    ".bar": [
+
+    ],
+    ".bar*": [
+
+    ],
+    ".bar**": [
+
+    ],
+    ".bar**/": [
+
+    ],
+    ".bar**/*": [
+
+    ],
+    ".bar**/**": [
+
+    ],
+    ".bar*/": [
+
+    ],
+    ".bar*/**": [
+
+    ],
+    ".bar.": [
+
+    ],
+    ".bar/": [
+
+    ],
+    ".bar/*": [
+
+    ],
+    ".bar/**": [
+
+    ],
+    ".dot*": [
+      "./.dot folder/.silly example.txt",
+      "./.dot folder/afoodle.txt",
+      "./.dot folder/serious_example.txt"
+    ],
+    ".foo": [
+
+    ],
+    ".foo*": [
+
+    ],
+    ".foo**": [
+
+    ],
+    ".foo**/": [
+
+    ],
+    ".foo**/*": [
+
+    ],
+    ".foo**/**": [
+
+    ],
+    ".foo*/": [
+
+    ],
+    ".foo*/**": [
+
+    ],
+    ".foo.": [
+
+    ],
+    ".foo/": [
+
+    ],
+    ".foo/*": [
+
+    ],
+    ".foo/**": [
+
+    ],
+    ".foo/bar": [
+
+    ],
+    ".foo/bar*": [
+
+    ],
+    ".foo/bar**": [
+
+    ],
+    ".foo/bar**/": [
+
+    ],
+    ".foo/bar**/*": [
+
+    ],
+    ".foo/bar**/**": [
+
+    ],
+    ".foo/bar*/": [
+
+    ],
+    ".foo/bar*/**": [
+
+    ],
+    ".foo/bar.": [
+
+    ],
+    ".foo/bar/": [
+
+    ],
+    ".foo/bar/*": [
+
+    ],
+    ".foo/bar/**": [
+
+    ],
+    "/**bar": [
+
+    ],
+    "/**bar*": [
+
+    ],
+    "/**bar**": [
+
+    ],
+    "/**bar**/": [
+
+    ],
+    "/**bar**/*": [
+
+    ],
+    "/**bar**/**": [
+
+    ],
+    "/**bar*/": [
+
+    ],
+    "/**bar*/**": [
+
+    ],
+    "/**bar.": [
+
+    ],
+    "/**bar/": [
+
+    ],
+    "/**bar/*": [
+
+    ],
+    "/**bar/**": [
+
+    ],
+    "/**foo": [
+
+    ],
+    "/**foo*": [
+
+    ],
+    "/**foo**": [
+
+    ],
+    "/**foo**/": [
+
+    ],
+    "/**foo**/*": [
+
+    ],
+    "/**foo**/**": [
+
+    ],
+    "/**foo*/": [
+
+    ],
+    "/**foo*/**": [
+
+    ],
+    "/**foo.": [
+
+    ],
+    "/**foo/": [
+
+    ],
+    "/**foo/*": [
+
+    ],
+    "/**foo/**": [
+
+    ],
+    "/**foo/bar": [
+
+    ],
+    "/**foo/bar*": [
+
+    ],
+    "/**foo/bar**": [
+
+    ],
+    "/**foo/bar**/": [
+
+    ],
+    "/**foo/bar**/*": [
+
+    ],
+    "/**foo/bar**/**": [
+
+    ],
+    "/**foo/bar*/": [
+
+    ],
+    "/**foo/bar*/**": [
+
+    ],
+    "/**foo/bar.": [
+
+    ],
+    "/**foo/bar/": [
+
+    ],
+    "/**foo/bar/*": [
+
+    ],
+    "/**foo/bar/**": [
+
+    ],
+    "/*bar": [
+
+    ],
+    "/*bar*": [
+
+    ],
+    "/*bar**": [
+
+    ],
+    "/*bar**/": [
+
+    ],
+    "/*bar**/*": [
+
+    ],
+    "/*bar**/**": [
+
+    ],
+    "/*bar*/": [
+
+    ],
+    "/*bar*/**": [
+
+    ],
+    "/*bar.": [
+
+    ],
+    "/*bar/": [
+
+    ],
+    "/*bar/*": [
+
+    ],
+    "/*bar/**": [
+
+    ],
+    "/*foo": [
+
+    ],
+    "/*foo*": [
+
+    ],
+    "/*foo**": [
+
+    ],
+    "/*foo**/": [
+
+    ],
+    "/*foo**/*": [
+
+    ],
+    "/*foo**/**": [
+
+    ],
+    "/*foo*/": [
+
+    ],
+    "/*foo*/**": [
+
+    ],
+    "/*foo.": [
+
+    ],
+    "/*foo/": [
+
+    ],
+    "/*foo/*": [
+
+    ],
+    "/*foo/**": [
+
+    ],
+    "/*foo/bar": [
+
+    ],
+    "/*foo/bar*": [
+
+    ],
+    "/*foo/bar**": [
+
+    ],
+    "/*foo/bar**/": [
+
+    ],
+    "/*foo/bar**/*": [
+
+    ],
+    "/*foo/bar**/**": [
+
+    ],
+    "/*foo/bar*/": [
+
+    ],
+    "/*foo/bar*/**": [
+
+    ],
+    "/*foo/bar.": [
+
+    ],
+    "/*foo/bar/": [
+
+    ],
+    "/*foo/bar/*": [
+
+    ],
+    "/*foo/bar/**": [
+
+    ],
+    "/bar": [
+
+    ],
+    "/bar*": [
+
+    ],
+    "/bar**": [
+
+    ],
+    "/bar**/": [
+
+    ],
+    "/bar**/*": [
+
+    ],
+    "/bar**/**": [
+
+    ],
+    "/bar*/": [
+
+    ],
+    "/bar*/**": [
+
+    ],
+    "/bar.": [
+
+    ],
+    "/bar/": [
+
+    ],
+    "/bar/*": [
+
+    ],
+    "/bar/**": [
+
+    ],
+    "/foo": [
+
+    ],
+    "/foo*": [
+
+    ],
+    "/foo**": [
+
+    ],
+    "/foo**/": [
+
+    ],
+    "/foo**/*": [
+
+    ],
+    "/foo**/**": [
+
+    ],
+    "/foo*/": [
+
+    ],
+    "/foo*/**": [
+
+    ],
+    "/foo.": [
+
+    ],
+    "/foo/": [
+
+    ],
+    "/foo/*": [
+
+    ],
+    "/foo/**": [
+
+    ],
+    "/foo/bar": [
+
+    ],
+    "/foo/bar*": [
+
+    ],
+    "/foo/bar**": [
+
+    ],
+    "/foo/bar**/": [
+
+    ],
+    "/foo/bar**/*": [
+
+    ],
+    "/foo/bar**/**": [
+
+    ],
+    "/foo/bar*/": [
+
+    ],
+    "/foo/bar*/**": [
+
+    ],
+    "/foo/bar.": [
+
+    ],
+    "/foo/bar/": [
+
+    ],
+    "/foo/bar/*": [
+
+    ],
+    "/foo/bar/**": [
+
+    ],
+    "bar": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "bar*": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "bar**": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "bar**/": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "bar**/*": [
+
+    ],
+    "bar**/**": [
+
+    ],
+    "bar*/": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "bar*/**": [
+
+    ],
+    "bar.": [
+
+    ],
+    "bar/": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt"
+    ],
+    "bar/*": [
+
+    ],
+    "bar/**": [
+
+    ],
+    "foo": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt",
+      "./foo/confoozing.txt",
+      "./foo/foo",
+      "./foo/foo.txt",
+      "./foo/some foo.text"
+    ],
+    "foo*": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt",
+      "./foo/confoozing.txt",
+      "./foo/foo",
+      "./foo/foo.txt",
+      "./foo/some foo.text"
+    ],
+    "foo**": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt",
+      "./foo/confoozing.txt",
+      "./foo/foo",
+      "./foo/foo.txt",
+      "./foo/some foo.text"
+    ],
+    "foo**/": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt",
+      "./foo/confoozing.txt",
+      "./foo/foo",
+      "./foo/foo.txt",
+      "./foo/some foo.text"
+    ],
+    "foo**/*": [
+
+    ],
+    "foo**/**": [
+
+    ],
+    "foo*/": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt",
+      "./foo/confoozing.txt",
+      "./foo/foo",
+      "./foo/foo.txt",
+      "./foo/some foo.text"
+    ],
+    "foo*/**": [
+
+    ],
+    "foo.": [
+
+    ],
+    "foo/": [
+      "./foo/bar/bar",
+      "./foo/bar/bar.txt",
+      "./foo/bar/baz/baz.txt",
+      "./foo/bar/some bar.txt",
+      "./foo/confoozing.txt",
+      "./foo/foo",
+      "./foo/foo.txt",
+      "./foo/some foo.text"
+    ],
+    "foo/*": [
+
+    ],
+    "foo/**": [
+
+    ],
+    "foo/bar": [
+
+    ],
+    "foo/bar*": [
+
+    ],
+    "foo/bar**": [
+
+    ],
+    "foo/bar**/": [
+
+    ],
+    "foo/bar**/*": [
+
+    ],
+    "foo/bar**/**": [
+
+    ],
+    "foo/bar*/": [
+
+    ],
+    "foo/bar*/**": [
+
+    ],
+    "foo/bar.": [
+
+    ],
+    "foo/bar/": [
+
+    ],
+    "foo/bar/*": [
+
+    ],
+    "foo/bar/**": [
+
+    ]
+  },
+  "all_files": [
+    "./.dot folder/.silly example.txt",
+    "./.dot folder/afoodle.txt",
+    "./.dot folder/serious_example.txt",
+    "./foo/some foo.text",
+    "./foo/confoozing.txt",
+    "./foo/foo.txt",
+    "./foo/foo",
+    "./foo/bar/some bar.txt",
+    "./foo/bar/bar.txt",
+    "./foo/bar/baz/baz.txt",
+    "./foo/bar/bar",
+    "./☃.txt",
+    "./file name.txt"
+  ]
+}

--- a/spec/permutations.json
+++ b/spec/permutations.json
@@ -1,785 +1,921 @@
 {
   "permutations": {
     "**/**bar": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/**bar*": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/**bar**": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/**bar**/": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/**bar**/*": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/**bar**/**": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/**bar*/": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/**bar*/**": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/**bar.": [
 
     ],
     "**/**bar/": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/**bar/*": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/**bar/**": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/**foo": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt",
-      "./foo/confoozing.txt",
-      "./foo/foo",
-      "./foo/foo.txt",
-      "./foo/some foo.text"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "**/**foo*": [
-      "./.dot folder/afoodle.txt",
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt",
-      "./foo/confoozing.txt",
-      "./foo/foo",
-      "./foo/foo.txt",
-      "./foo/some foo.text"
+      ".dot folder/afoodle.txt",
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "**/**foo**": [
-      "./.dot folder/afoodle.txt",
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt",
-      "./foo/confoozing.txt",
-      "./foo/foo",
-      "./foo/foo.txt",
-      "./foo/some foo.text"
+      ".dot folder/afoodle.txt",
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "**/**foo**/": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt",
-      "./foo/confoozing.txt",
-      "./foo/foo",
-      "./foo/foo.txt",
-      "./foo/some foo.text"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "**/**foo**/*": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt",
-      "./foo/confoozing.txt",
-      "./foo/foo",
-      "./foo/foo.txt",
-      "./foo/some foo.text"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "**/**foo**/**": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt",
-      "./foo/confoozing.txt",
-      "./foo/foo",
-      "./foo/foo.txt",
-      "./foo/some foo.text"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "**/**foo*/": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt",
-      "./foo/confoozing.txt",
-      "./foo/foo",
-      "./foo/foo.txt",
-      "./foo/some foo.text"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "**/**foo*/**": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt",
-      "./foo/confoozing.txt",
-      "./foo/foo",
-      "./foo/foo.txt",
-      "./foo/some foo.text"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "**/**foo.": [
 
     ],
     "**/**foo/": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt",
-      "./foo/confoozing.txt",
-      "./foo/foo",
-      "./foo/foo.txt",
-      "./foo/some foo.text"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "**/**foo/*": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt",
-      "./foo/confoozing.txt",
-      "./foo/foo",
-      "./foo/foo.txt",
-      "./foo/some foo.text"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "**/**foo/**": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt",
-      "./foo/confoozing.txt",
-      "./foo/foo",
-      "./foo/foo.txt",
-      "./foo/some foo.text"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "**/**foo/bar": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/**foo/bar*": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/**foo/bar**": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/**foo/bar**/": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/**foo/bar**/*": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/**foo/bar**/**": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/**foo/bar*/": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/**foo/bar*/**": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/**foo/bar.": [
 
     ],
     "**/**foo/bar/": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/**foo/bar/*": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/**foo/bar/**": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/*bar": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/*bar*": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/*bar**": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/*bar**/": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/*bar**/*": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/*bar**/**": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/*bar*/": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/*bar*/**": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/*bar.": [
 
     ],
     "**/*bar/": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/*bar/*": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/*bar/**": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/*foo": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt",
-      "./foo/confoozing.txt",
-      "./foo/foo",
-      "./foo/foo.txt",
-      "./foo/some foo.text"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "**/*foo*": [
-      "./.dot folder/afoodle.txt",
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt",
-      "./foo/confoozing.txt",
-      "./foo/foo",
-      "./foo/foo.txt",
-      "./foo/some foo.text"
+      ".dot folder/afoodle.txt",
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "**/*foo**": [
-      "./.dot folder/afoodle.txt",
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt",
-      "./foo/confoozing.txt",
-      "./foo/foo",
-      "./foo/foo.txt",
-      "./foo/some foo.text"
+      ".dot folder/afoodle.txt",
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "**/*foo**/": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt",
-      "./foo/confoozing.txt",
-      "./foo/foo",
-      "./foo/foo.txt",
-      "./foo/some foo.text"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "**/*foo**/*": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt",
-      "./foo/confoozing.txt",
-      "./foo/foo",
-      "./foo/foo.txt",
-      "./foo/some foo.text"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "**/*foo**/**": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt",
-      "./foo/confoozing.txt",
-      "./foo/foo",
-      "./foo/foo.txt",
-      "./foo/some foo.text"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "**/*foo*/": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt",
-      "./foo/confoozing.txt",
-      "./foo/foo",
-      "./foo/foo.txt",
-      "./foo/some foo.text"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "**/*foo*/**": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt",
-      "./foo/confoozing.txt",
-      "./foo/foo",
-      "./foo/foo.txt",
-      "./foo/some foo.text"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "**/*foo.": [
 
     ],
     "**/*foo/": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt",
-      "./foo/confoozing.txt",
-      "./foo/foo",
-      "./foo/foo.txt",
-      "./foo/some foo.text"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "**/*foo/*": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt",
-      "./foo/confoozing.txt",
-      "./foo/foo",
-      "./foo/foo.txt",
-      "./foo/some foo.text"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "**/*foo/**": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt",
-      "./foo/confoozing.txt",
-      "./foo/foo",
-      "./foo/foo.txt",
-      "./foo/some foo.text"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "**/*foo/bar": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/*foo/bar*": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/*foo/bar**": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/*foo/bar**/": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/*foo/bar**/*": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/*foo/bar**/**": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/*foo/bar*/": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/*foo/bar*/**": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/*foo/bar.": [
 
     ],
     "**/*foo/bar/": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/*foo/bar/*": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/*foo/bar/**": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/bar": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/bar*": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/bar**": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/bar**/": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/bar**/*": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/bar**/**": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/bar*/": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/bar*/**": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/bar.": [
 
     ],
     "**/bar/": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/bar/*": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/bar/**": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/foo": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt",
-      "./foo/confoozing.txt",
-      "./foo/foo",
-      "./foo/foo.txt",
-      "./foo/some foo.text"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "**/foo*": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt",
-      "./foo/confoozing.txt",
-      "./foo/foo",
-      "./foo/foo.txt",
-      "./foo/some foo.text"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "**/foo**": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt",
-      "./foo/confoozing.txt",
-      "./foo/foo",
-      "./foo/foo.txt",
-      "./foo/some foo.text"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "**/foo**/": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt",
-      "./foo/confoozing.txt",
-      "./foo/foo",
-      "./foo/foo.txt",
-      "./foo/some foo.text"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "**/foo**/*": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt",
-      "./foo/confoozing.txt",
-      "./foo/foo",
-      "./foo/foo.txt",
-      "./foo/some foo.text"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "**/foo**/**": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt",
-      "./foo/confoozing.txt",
-      "./foo/foo",
-      "./foo/foo.txt",
-      "./foo/some foo.text"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "**/foo*/": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt",
-      "./foo/confoozing.txt",
-      "./foo/foo",
-      "./foo/foo.txt",
-      "./foo/some foo.text"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "**/foo*/**": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt",
-      "./foo/confoozing.txt",
-      "./foo/foo",
-      "./foo/foo.txt",
-      "./foo/some foo.text"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "**/foo.": [
 
     ],
     "**/foo/": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt",
-      "./foo/confoozing.txt",
-      "./foo/foo",
-      "./foo/foo.txt",
-      "./foo/some foo.text"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "**/foo/*": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt",
-      "./foo/confoozing.txt",
-      "./foo/foo",
-      "./foo/foo.txt",
-      "./foo/some foo.text"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "**/foo/**": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt",
-      "./foo/confoozing.txt",
-      "./foo/foo",
-      "./foo/foo.txt",
-      "./foo/some foo.text"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "**/foo/bar": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/foo/bar*": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/foo/bar**": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/foo/bar**/": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/foo/bar**/*": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/foo/bar**/**": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/foo/bar*/": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/foo/bar*/**": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/foo/bar.": [
 
     ],
     "**/foo/bar/": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/foo/bar/*": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**/foo/bar/**": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**bar": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**bar*": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**bar**": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**bar**/": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**bar**/*": [
 
@@ -788,10 +924,11 @@
 
     ],
     "**bar*/": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**bar*/**": [
 
@@ -800,10 +937,11 @@
 
     ],
     "**bar/": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**bar/*": [
 
@@ -812,165 +950,318 @@
 
     ],
     "**foo": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt",
-      "./foo/confoozing.txt",
-      "./foo/foo",
-      "./foo/foo.txt",
-      "./foo/some foo.text"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "**foo*": [
-      "./.dot folder/afoodle.txt",
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt",
-      "./foo/confoozing.txt",
-      "./foo/foo",
-      "./foo/foo.txt",
-      "./foo/some foo.text"
+      ".dot folder/afoodle.txt",
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "**foo**": [
-      "./.dot folder/afoodle.txt",
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt",
-      "./foo/confoozing.txt",
-      "./foo/foo",
-      "./foo/foo.txt",
-      "./foo/some foo.text"
+      ".dot folder/afoodle.txt",
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "**foo**/": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt",
-      "./foo/confoozing.txt",
-      "./foo/foo",
-      "./foo/foo.txt",
-      "./foo/some foo.text"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "**foo**/*": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "**foo**/**": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "**foo*/": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt",
-      "./foo/confoozing.txt",
-      "./foo/foo",
-      "./foo/foo.txt",
-      "./foo/some foo.text"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "**foo*/**": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "**foo.": [
 
     ],
     "**foo/": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt",
-      "./foo/confoozing.txt",
-      "./foo/foo",
-      "./foo/foo.txt",
-      "./foo/some foo.text"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "**foo/*": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "**foo/**": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "**foo/bar": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**foo/bar*": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**foo/bar**": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**foo/bar**/": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**foo/bar**/*": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**foo/bar**/**": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**foo/bar*/": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**foo/bar*/**": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**foo/bar.": [
 
     ],
     "**foo/bar/": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**foo/bar/*": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "**foo/bar/**": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "*/**bar": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "*/**bar*": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "*/**bar**": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "*/**bar**/": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "*/**bar**/*": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "*/**bar**/**": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "*/**bar*/": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "*/**bar*/**": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "*/**bar.": [
 
     ],
     "*/**bar/": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "*/**bar/*": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "*/**bar/**": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "*/**foo": [
-
+      "foo/foo"
     ],
     "*/**foo*": [
-
+      ".dot folder/afoodle.txt",
+      "foo/confoozing.txt",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "*/**foo**": [
-
+      ".dot folder/afoodle.txt",
+      "foo/confoozing.txt",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "*/**foo**/": [
 
@@ -1036,49 +1327,95 @@
 
     ],
     "*/bar": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "*/bar*": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "*/bar**": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "*/bar**/": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "*/bar**/*": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "*/bar**/**": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "*/bar*/": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "*/bar*/**": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "*/bar.": [
 
     ],
     "*/bar/": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "*/bar/*": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "*/bar/**": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "*/foo": [
-
+      "foo/foo"
     ],
     "*/foo*": [
-
+      "foo/foo",
+      "foo/foo.txt"
     ],
     "*/foo**": [
-
+      "foo/foo",
+      "foo/foo.txt"
     ],
     "*/foo**/": [
 
@@ -1144,28 +1481,32 @@
 
     ],
     "*bar": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "*bar*": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "*bar**": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "*bar**/": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "*bar**/*": [
 
@@ -1174,10 +1515,11 @@
 
     ],
     "*bar*/": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "*bar*/**": [
 
@@ -1186,10 +1528,11 @@
 
     ],
     "*bar/": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "*bar/*": [
 
@@ -1198,120 +1541,221 @@
 
     ],
     "*foo": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt",
-      "./foo/confoozing.txt",
-      "./foo/foo",
-      "./foo/foo.txt",
-      "./foo/some foo.text"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "*foo*": [
-      "./.dot folder/afoodle.txt",
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt",
-      "./foo/confoozing.txt",
-      "./foo/foo",
-      "./foo/foo.txt",
-      "./foo/some foo.text"
+      ".dot folder/afoodle.txt",
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "*foo**": [
-      "./.dot folder/afoodle.txt",
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt",
-      "./foo/confoozing.txt",
-      "./foo/foo",
-      "./foo/foo.txt",
-      "./foo/some foo.text"
+      ".dot folder/afoodle.txt",
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "*foo**/": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt",
-      "./foo/confoozing.txt",
-      "./foo/foo",
-      "./foo/foo.txt",
-      "./foo/some foo.text"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "*foo**/*": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "*foo**/**": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "*foo*/": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt",
-      "./foo/confoozing.txt",
-      "./foo/foo",
-      "./foo/foo.txt",
-      "./foo/some foo.text"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "*foo*/**": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "*foo.": [
 
     ],
     "*foo/": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt",
-      "./foo/confoozing.txt",
-      "./foo/foo",
-      "./foo/foo.txt",
-      "./foo/some foo.text"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "*foo/*": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "*foo/**": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "*foo/bar": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "*foo/bar*": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "*foo/bar**": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "*foo/bar**/": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "*foo/bar**/*": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "*foo/bar**/**": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "*foo/bar*/": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "*foo/bar*/**": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "*foo/bar.": [
 
     ],
     "*foo/bar/": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "*foo/bar/*": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "*foo/bar/**": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     ".bar": [
 
@@ -1350,9 +1794,9 @@
 
     ],
     ".dot*": [
-      "./.dot folder/.silly example.txt",
-      "./.dot folder/afoodle.txt",
-      "./.dot folder/serious_example.txt"
+      ".dot folder/.silly example.txt",
+      ".dot folder/afoodle.txt",
+      ".dot folder/serious_example.txt"
     ],
     ".foo": [
 
@@ -1463,76 +1907,219 @@
 
     ],
     "/**foo": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "/**foo*": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "/**foo**": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "/**foo**/": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "/**foo**/*": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "/**foo**/**": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "/**foo*/": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "/**foo*/**": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "/**foo.": [
 
     ],
     "/**foo/": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "/**foo/*": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "/**foo/**": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "/**foo/bar": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "/**foo/bar*": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "/**foo/bar**": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "/**foo/bar**/": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "/**foo/bar**/*": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "/**foo/bar**/**": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "/**foo/bar*/": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "/**foo/bar*/**": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "/**foo/bar.": [
 
     ],
     "/**foo/bar/": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "/**foo/bar/*": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "/**foo/bar/**": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "/*bar": [
 
@@ -1571,76 +2158,219 @@
 
     ],
     "/*foo": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "/*foo*": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "/*foo**": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "/*foo**/": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "/*foo**/*": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "/*foo**/**": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "/*foo*/": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "/*foo*/**": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "/*foo.": [
 
     ],
     "/*foo/": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "/*foo/*": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "/*foo/**": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "/*foo/bar": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "/*foo/bar*": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "/*foo/bar**": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "/*foo/bar**/": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "/*foo/bar**/*": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "/*foo/bar**/**": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "/*foo/bar*/": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "/*foo/bar*/**": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "/*foo/bar.": [
 
     ],
     "/*foo/bar/": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "/*foo/bar/*": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "/*foo/bar/**": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "/bar": [
 
@@ -1679,100 +2409,247 @@
 
     ],
     "/foo": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "/foo*": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "/foo**": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "/foo**/": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "/foo**/*": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "/foo**/**": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "/foo*/": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "/foo*/**": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "/foo.": [
 
     ],
     "/foo/": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "/foo/*": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "/foo/**": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "/foo/bar": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "/foo/bar*": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "/foo/bar**": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "/foo/bar**/": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "/foo/bar**/*": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "/foo/bar**/**": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "/foo/bar*/": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "/foo/bar*/**": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "/foo/bar.": [
 
     ],
     "/foo/bar/": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "/foo/bar/*": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "/foo/bar/**": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "bar": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "bar*": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "bar**": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "bar**/": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "bar**/*": [
 
@@ -1781,10 +2658,11 @@
 
     ],
     "bar*/": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "bar*/**": [
 
@@ -1793,10 +2671,11 @@
 
     ],
     "bar/": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "bar/*": [
 
@@ -1805,133 +2684,237 @@
 
     ],
     "foo": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt",
-      "./foo/confoozing.txt",
-      "./foo/foo",
-      "./foo/foo.txt",
-      "./foo/some foo.text"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "foo*": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt",
-      "./foo/confoozing.txt",
-      "./foo/foo",
-      "./foo/foo.txt",
-      "./foo/some foo.text"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "foo**": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt",
-      "./foo/confoozing.txt",
-      "./foo/foo",
-      "./foo/foo.txt",
-      "./foo/some foo.text"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "foo**/": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt",
-      "./foo/confoozing.txt",
-      "./foo/foo",
-      "./foo/foo.txt",
-      "./foo/some foo.text"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "foo**/*": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "foo**/**": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "foo*/": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt",
-      "./foo/confoozing.txt",
-      "./foo/foo",
-      "./foo/foo.txt",
-      "./foo/some foo.text"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "foo*/**": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "foo.": [
 
     ],
     "foo/": [
-      "./foo/bar/bar",
-      "./foo/bar/bar.txt",
-      "./foo/bar/baz/baz.txt",
-      "./foo/bar/some bar.txt",
-      "./foo/confoozing.txt",
-      "./foo/foo",
-      "./foo/foo.txt",
-      "./foo/some foo.text"
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "foo/*": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "foo/**": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt",
+      "foo/confoozing.txt",
+      "foo/fake_gem.gem",
+      "foo/foo",
+      "foo/foo.txt",
+      "foo/some foo.text"
     ],
     "foo/bar": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "foo/bar*": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "foo/bar**": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "foo/bar**/": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "foo/bar**/*": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "foo/bar**/**": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "foo/bar*/": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "foo/bar*/**": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "foo/bar.": [
 
     ],
     "foo/bar/": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "foo/bar/*": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ],
     "foo/bar/**": [
-
+      "foo/bar/bar",
+      "foo/bar/bar.txt",
+      "foo/bar/baz/baz.txt",
+      "foo/bar/baz/baz2.txt",
+      "foo/bar/some bar.txt"
     ]
   },
   "all_files": [
-    "./.dot folder/.silly example.txt",
-    "./.dot folder/afoodle.txt",
-    "./.dot folder/serious_example.txt",
-    "./foo/some foo.text",
-    "./foo/confoozing.txt",
-    "./foo/foo.txt",
-    "./foo/foo",
-    "./foo/bar/some bar.txt",
-    "./foo/bar/bar.txt",
-    "./foo/bar/baz/baz.txt",
-    "./foo/bar/bar",
-    "./☃.txt",
-    "./file name.txt"
+    ".dot folder/.silly example.txt",
+    ".dot folder/afoodle.txt",
+    ".dot folder/serious_example.txt",
+    ".gitignore",
+    "foo/some foo.text",
+    "foo/confoozing.txt",
+    "foo/foo.txt",
+    "foo/foo",
+    "foo/bar/some bar.txt",
+    "foo/bar/bar.txt",
+    "foo/bar/baz/baz2.txt",
+    "foo/bar/baz/baz.txt",
+    "foo/bar/bar",
+    "foo/fake_gem.gem",
+    "☃.txt",
+    "file name.txt"
   ]
 }


### PR DESCRIPTION
Due to circumstances, we wanted to run this while in a minimal, hardened container without git.  While we could have taken the easy route and baked out the ownership at build time, I figured "how hard can it be to reimplement gitignore spec with Ruby globbing" and boy was _that_ a rabbithole.  Turns out transformation of one bonkers grammar to another is zalgo territory... who knew?
Meanwhile some geniuses had already done the hardest part by transforming it into regex, it just took the right invocation of search terms in a time of desperation to find what I needed.  So here we are.  It is slower than pure git (go figure), clocking in at about ~5 seconds on 5k files on a crusty 2018 MBP, BUT this approach is also more accurate and closely matching the intent of the codeowners spec in which the last patterns overwrite previous (with which gitignore has significant issues).
Since this was chonky and introduced a breaking change, gonna call this gem release 2.0